### PR TITLE
fix: return a Disposable from consumeDefinitionsService

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ You can also search for [packages](https://atom.io/packages/search?q=IDE) in Ato
 ![image](https://user-images.githubusercontent.com/16418197/109838982-48eee680-7c0c-11eb-88ee-5ab7889bb2af.png)
 ![image](https://user-images.githubusercontent.com/16418197/109838990-4a201380-7c0c-11eb-9bf2-7d3bf47ade5d.png)
 
-
 ## Contributing
 
 Please see the [contributing guidelines](CONTRIBUTING.md).

--- a/lib/main.js
+++ b/lib/main.js
@@ -28,7 +28,9 @@ export function deactivate() {
 }
 
 export function consumeDefinitionsService(provider) {
-  providerRegistry.addProvider(provider)
+  const providerDisposable = providerRegistry.addProvider(provider)
+  subscriptions.add(providerDisposable)
+  return providerDisposable
 }
 
 export function getClickProvider() {


### PR DESCRIPTION
Fixes the same problem as https://github.com/atom-community/atom-ide-outline/issues/128